### PR TITLE
Removing unnecessary flags and updating help section in lrs3_manifest.py

### DIFF
--- a/avhubert/preparation/README.md
+++ b/avhubert/preparation/README.md
@@ -53,11 +53,10 @@ It has dependency on [submitit](https://github.com/facebookincubator/submitit) a
 
 ### 4. Set up data directory
 ```sh
-python lrs3_manifest.py --lrs3 ${lrs3} --manifest ${lrs3}/file.list \
- --valid-ids /path/to/valid --vocab-size ${vocab_size}
+python lrs3_manifest.py --lrs3 ${lrs3} --valid-ids /path/to/valid --vocab-size ${vocab_size}
 ```
 
-This sets up data directory of trainval-only (~30h training data) and pretrain+trainval (~433h training data). It will first make a tokenizer based on sentencepiece model and set up target directory containing `${train|valid|test}.{tsv|wrd}`. `*.tsv` are manifest files and `*.wrd` are text labels.  `/path/to/valid` contains held-out clip ids used as validation set. The one used in our experiments can be found [here](data/lrs3-valid.id). 
+This sets up data directory of trainval-only (~30h training data) and pretrain+trainval (~433h training data). It will first make a tokenizer based on sentencepiece model and set up target directory containing `${train|valid|test}.{tsv|wrd}`. `*.tsv` are manifest files and `*.wrd` are text labels.  `/path/to/valid` contains held-out clip ids used as validation set. The one used in our experiments can be found [here](data/lrs3-valid.id). The `${vocab_size}` is optional and is set to 1000 by default.
 
 
 ## VoxCeleb2 Preprocessing

--- a/avhubert/preparation/lrs3_manifest.py
+++ b/avhubert/preparation/lrs3_manifest.py
@@ -18,7 +18,7 @@ def main():
     parser = argparse.ArgumentParser(description='LRS3 tsv preparation', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--lrs3', type=str, help='lrs3 root dir')
     parser.add_argument('--valid-ids', type=str, help='a list of valid ids')
-    parser.add_argument('--vocab-size', type=int, default=1000, help='a list of valid ids')
+    parser.add_argument('--vocab-size', type=int, default=1000, help='length of vocab size to be generated (optional)')
     args = parser.parse_args()
     file_list, label_list = f"{args.lrs3}/file.list", f"{args.lrs3}/label.list"
     assert os.path.isfile(file_list) , f"{file_list} not exist -> run lrs3_prepare.py first"


### PR DESCRIPTION
Updated the readme in preparations folder:
Removed the --manifest flag from the step 4 of the LRS3 preprocessing step. Also updated the readme to show the default value of vocab_size.

Updated lrs3_manifest.py file:
Updated the help section of --vocab-size argument.