### PR TITLE
Minor modifications to support MuAViC trained models

### DIFF
--- a/avhubert/hubert.py
+++ b/avhubert/hubert.py
@@ -314,6 +314,21 @@ class AVHubertConfig(FairseqDataclass):
     )
     no_scale_embedding: bool = field(default=True, metadata={'help': 'scale embedding'})
 
+    # configs in new fairseq
+    required_seq_len_multiple: int = field(
+        default=1,
+        metadata={
+            "help": "pad the input to encoder such that the sequence length is divisible by multiple"
+        },
+    )
+    layer_type: ChoiceEnum(["transformer", "conformer"]) = field(
+        default="transformer", metadata={"help": "layer type in encoder"}
+    )
+    checkpoint_activations: bool = field(
+        default=False,
+        metadata={"help": "recompute activations and save memory for extra compute"},
+    )
+
 class SubModel(nn.Module):
     def __init__(self, resnet=None, input_dim=None, cfg=None):
         super().__init__()

--- a/avhubert/hubert_dataset.py
+++ b/avhubert/hubert_dataset.py
@@ -238,10 +238,10 @@ class AVHubertDataset(FairseqDataset):
         if self.store_labels:
             label = self.label_list[label_idx][index]
         else:
-            with open(self.label_paths[label_idx]) as f:
+            with open(self.label_paths[label_idx], 'rb') as f:
                 offset_s, offset_e = self.label_offsets_list[label_idx][index]
                 f.seek(offset_s)
-                label = f.read(offset_e - offset_s)
+                label = f.read(offset_e - offset_s).decode("utf-8").strip()
 
         if self.label_processors is not None:
             label = self.label_processors[label_idx](label)

--- a/avhubert/hubert_pretraining.py
+++ b/avhubert/hubert_pretraining.py
@@ -48,7 +48,7 @@ class LabelEncoderS2SToken(object):
         self.dictionary = dictionary
 
     def __call__(self, label: str) -> List[str]:
-        label = self.bpe_tokenizer.encode(label.lower())
+        label = self.bpe_tokenizer.encode(label)
         return self.dictionary.encode_line(
             label, append_eos=True, add_if_not_exist=False,
         ).long()

--- a/avhubert/hubert_pretraining.py
+++ b/avhubert/hubert_pretraining.py
@@ -64,6 +64,9 @@ class AVHubertPretrainingConfig(FairseqDataclass):
     data: str = field(
         default=MISSING, metadata={"help": "path to data directory"}
     )
+    input_modality: str = field(
+        default=MISSING, metadata={"help": "placeholder (for compatibility)"}
+    )
     labels: List[str] = field(
         default_factory=lambda: ["ltr"],
         metadata={

--- a/avhubert/infer_s2s.py
+++ b/avhubert/infer_s2s.py
@@ -116,7 +116,7 @@ def _main(cfg, output_file):
 
     utils.import_user_module(cfg.common)
     models, saved_cfg, task = checkpoint_utils.load_model_ensemble_and_task([cfg.common_eval.path])
-    models = [model.eval().cuda() for model in models]
+    # models = [model.eval().cuda() for model in models]
     task.cfg.modalities = cfg.override.modalities
     if cfg.override.tokenizer_bpe_model is not None:
         task.cfg.tokenizer_bpe_model = cfg.override.tokenizer_bpe_model


### PR DESCRIPTION
The following is the list for all the modifications made by this Pull Request:

- Updated fairseq submodule to commit [272c4c51](https://github.com/facebookresearch/fairseq/commit/272c4c5197250997148fb12c0db6306035f166a4) instead of [afc77bd](https://github.com/facebookresearch/fairseq/commit/afc77bdf4bb51453ce76f1572ef2ee6ddcda8eeb) to match the internal version.
- Added some configuration arguments in `hubert.py` and `hubert_pretraining.py` scripts to support fairseq's updated version.
- Fixed a bug where the pre-trained w2v_model has different encoder embedding dimension than the configured one:
https://github.com/Anwarvic/av_hubert_muavic/blob/main/avhubert/hubert_asr.py#L474-L475

This PR works fine with  all MuAViC checkpoints & [large_vox_iter5.pt](https://facebookresearch.github.io/av_hubert/) checkpoint.